### PR TITLE
Various fixes

### DIFF
--- a/js/griddly-bear.js
+++ b/js/griddly-bear.js
@@ -429,6 +429,10 @@ $.widget('gb.grrr', {
                         self.options.columns[i].primary) {
                         td.attr('data-primary', 'true');
                     }
+                    if (self.options.columns[i].id == column &&
+                        self.options.columns[i].hidden) {
+                        td.addClass('hidden');
+                    }
                 }
                 lastRow.append(td);
             });


### PR DESCRIPTION
Hiding columns now hides the column data.
Leaving out the pagination options doesn't cause an error to be thrown.
