### PR TITLE
adding formatRow() option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -10,10 +10,26 @@ $('#grid').grrr({
 
 | Option        | Default Value           | Description  |
 | :------------- | :------------- | :----- |
+| [formatRow](#formatrow) ||Allows formatting rows before rendering in the grid |
 | [rowsPerPage](#rowsperpage) | 10 | |
 | [rowsPerPageOptions](#rowsperpageoptions) | [5,10,15] | |
 | [alternatingRows](#alternatingrows) | true | |
 | [multiSelect](#multiselect)      | false | Enables the ability to select multiple rows at once |
+
+## formatRow
+
+Allows formatting a row value before it is rendered in the grid. Example: 
+
+```js
+$('#grid').grrr({
+    formatRow: function(data) {
+        data.status = data.status.toUpperCase();
+        return data;
+    }
+});
+```
+
+This example will transform the value in `data.status` to all upper case characters, then return the row for rendering.
 
 ## rowsPerPage
 

--- a/js/griddly-bear.js
+++ b/js/griddly-bear.js
@@ -25,7 +25,8 @@
             alternatingRows: true,
             menuButtonIconClass: "icol-application-view-columns",
             loadComplete: function(){},
-            onColumnValueChanged: function(id, value){}
+            onColumnValueChanged: function(id, value){},
+            formatRow: function(row){return row}
         },
         staticState: {
             mobile: false,
@@ -590,6 +591,7 @@
             });
 
             $.each(data.rows, function(rowIndex, row){
+                row = self.options.formatRow(row);
                 var tr = $('<tr />');
                 tr.addClass('gb-data-row')
                 if (self.options.alternatingRows && !(rowIndex % 2)) {


### PR DESCRIPTION
Allows formatting a row value before it is rendered in the grid. Example: 

``` js
$('#grid').grrr({
    formatRow: function(data) {
        data.status = data.status.toUpperCase();
        return data;
    }
});
```

This example will transform the value in `data.status` to all upper case characters, then return the row for rendering.
