### PR TITLE
Added a columnSelector display option 

### DIFF
--- a/css/griddly-bear.css
+++ b/css/griddly-bear.css
@@ -338,3 +338,32 @@
 .gb-button-box .gb-button img {
     vertical-align: middle;
 }
+
+/* styles to support the column picker functionality */
+.gb-column-picker {
+    z-index: 999;
+    background-color: #f5f5f5;
+    padding: 4px 10px 10px 10px;
+    position: absolute;
+    bottom: 36px;
+    border: 1px solid #ccc;
+    opacity: .92;
+}
+
+.gb-column-picker hr {
+    color: #acacac;
+    background-color: #cfcfcf;
+    height: 1px;
+    margin: 4px 0;
+}
+.gb-column-picker ul {
+    margin-left: 12px;
+}
+input[type="checkbox"].gb-column-picker-cb {
+    margin: 0 3px 0 0;
+}
+
+.gb-column-picker-li {
+    list-style-type: none;
+    padding: 2px 0;
+}

--- a/docs/options.md
+++ b/docs/options.md
@@ -15,6 +15,7 @@ $('#grid').grrr({
 | [rowsPerPageOptions](#rowsperpageoptions) | [5,10,15] | |
 | [alternatingRows](#alternatingrows) | true | |
 | [multiSelect](#multiselect)      | false | Enables the ability to select multiple rows at once |
+| [columnSelector](#columnselector)      | false | Adds a button to the footer which displays a column picker dialog |
 
 ## formatRow
 
@@ -52,3 +53,10 @@ $('#grid').grrr({
 
 When this is enabled, the [getSelectedRow() method](methods.md#getselectedrow) with return an array of all
 selected rows, whereas it returns an object of the selected row when `multiSelect` is false.
+
+##columnselector
+Values: `true`|`false`
+
+When enabled, it adds a button to the first position on the footer. When the button is clicked, it displays a
+popup containing a list of checkboxes with the column title indicating the hidden status. Toggling the checkboxes
+toggles the class `hidden` on the table heading and cells in that column.


### PR DESCRIPTION
Added an option to griddly bear, columnSelector. If it's true, a button will be added to the footer that displays a dialog with a checkbox list of all the table columns hidden or not. You can then select which ones to display. If there's a column that doesn't have a title property defined, the checkbox list will use the column.id field as an identifier, but the table heading will be a non-breaking space.
