### PR TITLE
draw pagination always if > 1 page of data

### DIFF
--- a/js/griddly-bear.js
+++ b/js/griddly-bear.js
@@ -530,8 +530,7 @@
                 pagination.append(ul);
             }
 
-
-            if (self.state.rows > self.options.rowsPerPageOptions[0]) {
+            if (this.state.totalPages > 1) {
                 pagination.append(rowsPerPageOptions);
 
                 var pages = $("<div />")


### PR DESCRIPTION
Previous code only drew pagination if the number of rows was greater than the first value in the `rowsPerPageOptions`. Which works great if the number of rows per page just happens to match that value. 

If it is less than that, but greater than the `rowsPerPage`, pagination wouldn't be drawn.
