### PR TITLE
Implemented column reordering by drag-drop

### DIFF
--- a/css/griddly-bear.css
+++ b/css/griddly-bear.css
@@ -367,3 +367,6 @@ input[type="checkbox"].gb-column-picker-cb {
     list-style-type: none;
     padding: 2px 0;
 }
+.gb-placeholder {
+    background-color: #EEEEEE;
+}


### PR DESCRIPTION
Also added events to modify the options.columns when columns are toggled or reordered.

This implements jquery ui sortable on the table headings. When the sorting is done, the event callback rearranges the columns in the `tbody` and triggers a custom event `this.events.columnsResorted`, which has a listener that will reorder the `this.options.columns` array to match the rearranged table headings.

This PR also includes changes to the column picker functionality. It triggers an event, `this.events.columnVisibilityChanged` when any of the columns have been toggled on or off. The listener for this event modifies the `hidden` property of the associated object in the this.options.columns array.

The purpose of the custom events is to make sure that the `options.columns` array, which is used to build the table, maintains the current state of the table as the DOM changes so that it can be saved.

Finally, I changed assignments of `self = this` to `_this = this` since `self` represents the `window` object in the global scope, so we don't want to accidentally read or set properties globally. If someone has a strong preference for `that` or `foo` or whatever, I'm happy to change it.
