### PR TITLE
this.option.filters should be a type 'Object' not 'Array'

### DIFF
--- a/js/griddly-bear.js
+++ b/js/griddly-bear.js
@@ -1281,7 +1281,7 @@
         },
         clearFilters: function()
         {
-            this.option('filters', []);
+            this.option('filters', {});
         },
         toggleFilters: function()
         {


### PR DESCRIPTION
Casting `this.option.filters` to array is making it buggy?
