### PR TITLE
Setting column default width

### DIFF
--- a/js/griddly-bear.js
+++ b/js/griddly-bear.js
@@ -8,7 +8,8 @@
             sortable: true,
             filterable: true,
             filterOptions: {'placeholder': 'Search...'},
-            dataType: null
+            dataType: null,
+            minWidth: 150
         },
         events: {
             columnsResorted: 'columnResorted',


### PR DESCRIPTION
Not setting the width was causing all the columns to disappear
on screens with low real estate.
