### PR TITLE
Adding internal column concept

### DIFF
--- a/js/griddly-bear.js
+++ b/js/griddly-bear.js
@@ -7,6 +7,7 @@
             hidden: false,
             sortable: true,
             filterable: true,
+            internal: false,
             filterOptions: {'placeholder': 'Search...'},
             dataType: null,
             minWidth: 150
@@ -371,6 +372,10 @@
 
             var popoverContent = $('<ul></ul>');
             $.each(this.options.columns, function(index, column) {
+                if (column.internal) {
+                    return true;
+                }
+
                 var columnSelectCb = $('<input />')
                     .attr({
                         type: "checkbox",
@@ -659,6 +664,11 @@
 
             $.each(this.options.columns, function(index, column) {
                 column = $.extend({}, _this.columnDefaults, column);
+
+                if (column.internal) {
+                    return true;
+                }
+
                 var th = $('<th />').attr('data-id', column.id);
 
                 if (column.required) {


### PR DESCRIPTION
Adding the ability to have internal columns, columns that are never
rendered in the grid and are not selectable in the column chooser.
These columns are only for internal use of the grid.
