### PR TITLE
Add min-height to Griddly Bear Grids

### DIFF
--- a/css/griddly-bear.css
+++ b/css/griddly-bear.css
@@ -153,6 +153,10 @@
     background: rgba(223, 223, 223, .5);
 }
 
+.gb-data-table .gb-data-row .gb-data-cell .gb-cell-min-height {
+    height: 17px;
+}
+
 .gb-data-table tr th:not(:last-child).sorting_asc,
 .gb-data-table tr th:not(:last-child).sorting_desc,
 .gb-data-table tr td:not(:last-child).sorting {

--- a/js/griddly-bear.js
+++ b/js/griddly-bear.js
@@ -875,7 +875,9 @@
                     $.each(columns, function(index, column) {
                         var td = $('<td />');
                         var label = $('<span />');
+                        var div = $('<div />');
                         label.addClass('gb-vertical-label').html(_this.options.columns[index].title + ": ");
+                        div.addClass('gb-cell-min-height');
                         td
                             .addClass('gb-data-cell')
                             .attr('data-id', column);
@@ -921,12 +923,12 @@
                                 });
 
                                 checkbox.append(input);
-                                td.append(checkbox);
+                                div.append(checkbox);
 
                                 break;
                             case 'string':
                             default:
-                                td
+                                div
                                     .append(label)
                                     .append(
                                         _this._formatColumnData(
@@ -936,6 +938,7 @@
                                         )
                                     );
                         }
+                        td.append(div);
                         for (var i in _this.options.columns) {
                             if (_this.options.columns[i].id == column &&
                                 _this.options.columns[i].primary != undefined &&


### PR DESCRIPTION
Added workaround to Griddly Bear grids to for grid rows to have a
min-height.  Update the CSS and Javascript to reflect using a floated
div in order to provide rows with no data a minimum height.
