### PR TITLE
Fix issue in GB on touch devices related to filtering.

### DIFF
--- a/js/griddly-bear.js
+++ b/js/griddly-bear.js
@@ -796,6 +796,16 @@
                 }
             });
         },
+        _disableReorderableColumns: function() {
+            var _this = this,
+                selector = "table.gb-data-table>thead>tr.gb-data-table-header-row"
+            this.element.find(selector).sortable('option', 'disabled', true);
+        },
+        _enableReorderableColumns: function() {
+            var _this = this,
+                selector = "table.gb-data-table>thead>tr.gb-data-table-header-row"
+            this.element.find(selector).sortable('option', 'disabled', false);
+        },
         _setReorderableColumns: function() {
             var _this = this,
                 selector = "table.gb-data-table>thead>tr.gb-data-table-header-row"
@@ -1422,8 +1432,10 @@
             this.state.filtersOn = !this.state.filtersOn;
 
             if (this.state.filtersOn) {
+                this._disableReorderableColumns();
                 $('input.filter', this.element).show();
             } else {
+                this._enableReorderableColumns();
                 $('input.filter', this.element).hide();
             }
         },


### PR DESCRIPTION
- Address an issue on touch devices (iOS/iPad etc) where column filtering was not possible.
- Column reordering can now only be performed on grids when column filters aren't showing inputs.
